### PR TITLE
Change input of DBus.Introspection.parseXML to Text

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ library:
   dependencies:
     - base >= 4.7 && < 5
     - bytestring
+    - text
     - containers
     - dbus >= 1.0.0 && < 2.0.0
     - filepath

--- a/src/StatusNotifier/Util.hs
+++ b/src/StatusNotifier/Util.hs
@@ -17,14 +17,13 @@ import           Data.Word
 import           Language.Haskell.TH
 import           Network.Socket (ntohl)
 import           StatusNotifier.TH
-import           System.IO
-import           System.IO.Unsafe
-import           System.Log.Handler.Simple
+import qualified Data.Text.IO as TIO
+import           Data.Text (pack)
 import           System.Log.Logger
 
 getIntrospectionObjectFromFile :: FilePath -> T.ObjectPath -> Q I.Object
 getIntrospectionObjectFromFile filepath nodePath = runIO $
-  head . maybeToList . I.parseXML nodePath <$> readFile filepath
+  head . maybeToList . I.parseXML nodePath <$> TIO.readFile filepath
 
 generateClientFromFile :: G.GenerationParams -> Bool -> FilePath -> Q [Dec]
 generateClientFromFile params useObjectPath filepath = do
@@ -122,7 +121,7 @@ getInterfaceAt
   -> T.ObjectPath
   -> IO (Either M.MethodError (Maybe I.Object))
 getInterfaceAt client bus path =
-  right (I.parseXML "/") <$> introspect client bus path
+  right (I.parseXML "/" . pack) <$> introspect client bus path
 
 findM :: Monad m => (a -> m Bool) -> [a] -> m (Maybe a)
 findM p [] = return Nothing


### PR DESCRIPTION
To allow building with dbus 1.2.1

In the second case, that String that I had to call `pack` on is apparently coming from the call to dbus's `generateClient` in StatusNotifier/TH.hs. Maybe that generator could also be updated to return Text to match? @rblaze