### PR TITLE
Enable building against newer tools

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -20,6 +20,7 @@ library:
   source-dirs: src
   dependencies:
     - base >= 4.7 && < 5
+    - byte-order
     - bytestring
     - bytestring-to-vector
     - containers
@@ -27,7 +28,6 @@ library:
     - filepath
     - hslogger
     - lens
-    - network < 3.0.0.0
     - template-haskell
     - text
     - transformers

--- a/src/StatusNotifier/Util.hs
+++ b/src/StatusNotifier/Util.hs
@@ -15,10 +15,10 @@ import qualified Data.Vector.Storable as VS
 import           Data.Vector.Storable.ByteString
 import           Data.Word
 import           Language.Haskell.TH
-import           Network.Socket (ntohl)
 import           StatusNotifier.TH
 import qualified Data.Text.IO as TIO
 import           Data.Text (pack)
+import           System.ByteOrder (fromBigEndian)
 import           System.Log.Logger
 
 getIntrospectionObjectFromFile :: FilePath -> T.ObjectPath -> Q I.Object
@@ -60,7 +60,7 @@ convertARGBToABGR bits = (blue `shift` 16) .|. (red `shift` (-16)) .|. green .|.
 
 networkToSystemByteOrder :: BS.ByteString -> BS.ByteString
 networkToSystemByteOrder original =
-  vectorToByteString $ VS.map (convertARGBToABGR . ntohl) $ byteStringToVector original
+  vectorToByteString $ VS.map (convertARGBToABGR . fromBigEndian) $ byteStringToVector original
 
 maybeToEither :: b -> Maybe a -> Either b a
 maybeToEither = flip maybe Right . Left

--- a/src/StatusNotifier/Watcher/Service.hs
+++ b/src/StatusNotifier/Watcher/Service.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, FlexibleContexts #-}
 module StatusNotifier.Watcher.Service where
 
 import           Control.Arrow

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@ resolver: lts-11.7
 packages:
 - .
 extra-deps:
+- byte-order-0.1.2.0
 - dbus-1.2.1
 - dbus-hslogger-0.1.0.1
 nix:


### PR DESCRIPTION
Remove the dependency on the old version of the `network` library, as well as a compiler error that seems to have cropped up in ghc-8.8.

Tested against the current haskell-updates branch in nixos (plus some other fixes).