### PR TITLE
Change ProtocolVersion to 0

### DIFF
--- a/src/StatusNotifier/Watcher/Service.hs
+++ b/src/StatusNotifier/Watcher/Service.hs
@@ -111,7 +111,7 @@ buildWatcher WatcherParams
 
       isStatusNotifierHostRegistered = not . null <$> readMVar notifierHosts
 
-      protocolVersion = return 1 :: IO Int32
+      protocolVersion = return 0 :: IO Int32
 
       filterDeadService :: String -> MVar [ItemEntry] -> IO [ItemEntry]
       filterDeadService deadService mvar = modifyMVar mvar $


### PR DESCRIPTION
Other StatusNotifierWatcher processes (particularly, KDE's and Gnome's) report 0 for Protocol version. Matching this version fixed several programs reporting that "SNI is unavailable".