### PR TITLE
Fix Nix CI/tests when dbus-daemon is unavailable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,30 +4,44 @@
     flake-utils.url = "github:numtide/flake-utils";
     git-ignore-nix.url = github:hercules-ci/gitignore.nix/master;
   };
-  outputs = { self, flake-utils, nixpkgs, git-ignore-nix }:
-  let
+  outputs = {
+    self,
+    flake-utils,
+    nixpkgs,
+    git-ignore-nix,
+  }: let
     overlay = final: prev: {
       haskellPackages = prev.haskellPackages.override (old: {
-        overrides = prev.lib.composeExtensions (old.overrides or (_: _: {}))
-        (hself: hsuper: {
-          status-notifier-item =
-            hself.callCabal2nix "status-notifier-item"
-            (git-ignore-nix.lib.gitignoreSource ./.)
-            { };
-        });
+        overrides =
+          prev.lib.composeExtensions (old.overrides or (_: _: {}))
+          (hself: hsuper: {
+            status-notifier-item =
+              prev.haskell.lib.overrideCabal
+              (hself.callCabal2nix "status-notifier-item"
+                (git-ignore-nix.lib.gitignoreSource ./.)
+                {})
+              (drv: {
+                # Integration tests start an isolated D-Bus via `dbus-daemon`.
+                testToolDepends = (drv.testToolDepends or []) ++ [final.dbus];
+              });
+          });
       });
     };
-    overlays = [ overlay ];
-  in flake-utils.lib.eachDefaultSystem (system:
-  let pkgs = import nixpkgs { inherit system overlays; config.allowBroken = true; };
+    overlays = [overlay];
   in
-  rec {
-    devShell = pkgs.haskellPackages.shellFor {
-      packages = p: [ p.status-notifier-item ];
-      buildInputs = [
-        pkgs.zlib.dev
-      ];
-    };
-    defaultPackage = pkgs.haskellPackages.status-notifier-item;
-  }) // { inherit overlay overlays; } ;
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system overlays;
+        config.allowBroken = true;
+      };
+    in rec {
+      devShell = pkgs.haskellPackages.shellFor {
+        packages = p: [p.status-notifier-item];
+        buildInputs = [
+          pkgs.dbus
+          pkgs.zlib.dev
+        ];
+      };
+      defaultPackage = pkgs.haskellPackages.status-notifier-item;
+    }) // {inherit overlay overlays;};
 }

--- a/package.yaml
+++ b/package.yaml
@@ -70,6 +70,7 @@ tests:
       - dbus >= 1.2.1 && < 2.0.0
       - containers
       - directory
+      - filepath
       - hslogger
       - hspec
       - process

--- a/status-notifier-item.cabal
+++ b/status-notifier-item.cabal
@@ -113,6 +113,7 @@ test-suite status-notifier-item-test
     , containers
     , dbus >=1.2.1 && <2.0.0
     , directory
+    , filepath
     , hslogger
     , hspec
     , process


### PR DESCRIPTION
## Summary
This PR upstreams the dbus test-environment fixes currently on `fix/dbus-session-config-tests`.

It includes:
- `afd303f` Fix Nix test bus setup for dbus-daemon
- `acc61e6` Skip integration tests when dbus-daemon is unavailable

## Why
Downstream Nix builds in the taffybar ecosystem currently fail with:
`dbus-daemon: ... posix_spawnp: does not exist`

Merging this unblocks downstream builds without requiring ad-hoc pinning.