### PR TITLE
Skip D-Bus integration tests when dbus-daemon is unavailable

### DIFF
--- a/test/TestSupport.hs
+++ b/test/TestSupport.hs
@@ -9,7 +9,7 @@ module TestSupport
   ) where
 
 import Control.Concurrent (threadDelay)
-import Control.Exception (SomeException, bracket, try)
+import Control.Exception (SomeException, displayException, finally, try)
 import Control.Monad (filterM)
 import DBus (busName_, objectPath_)
 import DBus.Client
@@ -59,8 +59,14 @@ findDbusSessionConfig = do
         _ -> Nothing
 
 withIsolatedSessionBus :: ActionWith () -> IO ()
-withIsolatedSessionBus action =
-  bracket setup teardown (const $ action ())
+withIsolatedSessionBus action = do
+  setupResult <- (try setup :: IO (Either SomeException BusEnv))
+  case setupResult of
+    Right env -> action () `finally` teardown env
+    Left e ->
+      pendingWith $
+        "Skipping D-Bus integration test: "
+          <> displayException e
 
 setup :: IO BusEnv
 setup = do


### PR DESCRIPTION
Supersedes #10 with the same effective fix, rebased on current `master`.

This keeps upstream's recent test-bus changes and adds the missing skip behavior for environments where `dbus-daemon` is not available in PATH.